### PR TITLE
Changed launch url to match documentation.

### DIFF
--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -19,7 +19,7 @@
     "AutoRenter.API": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000/api/locations",
+      "launchUrl": "http://localhost:3000/api/locations",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
The launch url was set to use port 5000, but all of our documentation directed the user to 3000.  I changed the port to match.