### PR TITLE
Repair Heroku Deployment

### DIFF
--- a/AutoRenter.Api/Program.cs
+++ b/AutoRenter.Api/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -8,20 +9,56 @@ namespace AutoRenter.Api
     {
         public static void Main(string[] args)
         {
-            var config = new ConfigurationBuilder()
+            var config = BuildConfiguration(args);
+            var webHost = BuildWebHost(config);
+            webHost.Run();
+        }
+
+        private static IWebHost BuildWebHost(IConfigurationRoot config)
+        {
+            var envUrls = Environment.GetEnvironmentVariable("ASPNETCORE_URLS");
+            if (!string.IsNullOrWhiteSpace(envUrls))
+            {
+                return BuildHostWithUrls(config, envUrls);
+            }
+
+            if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")
+            {
+                return BuildHostWithUrls(config, "http://*:3000");
+            }
+
+            return BuildHost(config);
+        }
+
+        private static IConfigurationRoot BuildConfiguration(string[] args)
+        {
+            return new ConfigurationBuilder()
                 .AddCommandLine(args)
                 .AddEnvironmentVariables("ASPNETCORE_")
                 .Build();
+        }
 
-            var host = new WebHostBuilder()
+        private static IWebHost BuildHostWithUrls(IConfigurationRoot config, string urls)
+        {
+            return new WebHostBuilder()
+                .UseConfiguration(config)
+                .UseKestrel()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .UseUrls(urls)
+                .Build();
+        }
+
+        private static IWebHost BuildHost(IConfigurationRoot config)
+        {
+            return new WebHostBuilder()
                 .UseConfiguration(config)
                 .UseKestrel()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();
-
-            host.Run();
         }
     }
 }

--- a/AutoRenter.Api/Program.cs
+++ b/AutoRenter.Api/Program.cs
@@ -19,7 +19,7 @@ namespace AutoRenter.Api
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseStartup<Startup>()
-                .UseUrls("http://127.0.0.1:3000")
+                //.UseUrls("http://127.0.0.1:3000")
                 .Build();
 
             host.Run();

--- a/AutoRenter.Api/Program.cs
+++ b/AutoRenter.Api/Program.cs
@@ -19,7 +19,6 @@ namespace AutoRenter.Api
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()
                 .UseStartup<Startup>()
-                //.UseUrls("http://127.0.0.1:3000")
                 .Build();
 
             host.Run();

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ These instructions will cover usage information for the API and the optional dev
 4. To run api tests, navigate to a test folder (e.g., `./AutoRenter.Api.Tests`) and run `dotnet test'.
 5. To run all api tests in Bash run './RunTests.sh'.
 6. Ensure the ASPNETCORE_ENVIRONMENT variable is set to development. On Windows: `set ASPNETCORE_ENVIRONMENT=Development`. On Unix based OS: `export ASPNETCORE_ENVIRONMENT=Development`.
-6. To run the app, navigate to the `AutoRenter.Api` folder and run `dotnet run`.
+7. To run the app, navigate to the `AutoRenter.Api` folder and run `dotnet run`.
 
 
 ### Browse the app

--- a/README.md
+++ b/README.md
@@ -43,11 +43,16 @@ These instructions will cover usage information for the API and the optional dev
 ### Browse the app
 
 After successfully starting the API app, you should be able to view data by browsing to [http://127.0.0.1:3000/api/locations](http://127.0.0.1:3000/api/locations).
+
+  > Note that in some cases the port number may be something other than 3000. For example, in my development environment the app runs on port 5000. This is what appears in my console when the app is launched: `Now listening on: http://localhost:5000`.
+
 For more in-depth testing, use a web debugging tool such as [Fiddler](https://www.telerik.com/download/fiddler) or [Postman](https://www.getpostman.com/).
 
 ### API Route Documentation
 
 Once running locally, you can access API route documentation (useful for those consuming the API) by going to: [http://localhost:3000/docs/api/](http://localhost:3000/docs/api/)
+
+  > NOTE: The adjust the port as necessary. For example, the app runs on port 5000 in my development environment.
 
 ### Docker Development
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These instructions will cover usage information for the API and the optional dev
    a. Note: running will also build.
 4. To run api tests, navigate to a test folder (e.g., `./AutoRenter.Api.Tests`) and run `dotnet test'.
 5. To run all api tests in Bash run './RunTests.sh'.
+6. Ensure the ASPNETCORE_ENVIRONMENT variable is set to development. On Windows: `set ASPNETCORE_ENVIRONMENT=Development`. On Unix based OS: `export ASPNETCORE_ENVIRONMENT=Development`.
 6. To run the app, navigate to the `AutoRenter.Api` folder and run `dotnet run`.
 
 


### PR DESCRIPTION
The Heroku deployment was showing an attempt to bind to http://127.0.0.1:3000 in the logs. This was specified at program start before processing configuration settings so a change was needed to the code.